### PR TITLE
added norwegian pattern

### DIFF
--- a/quotequail/_patterns.py
+++ b/quotequail/_patterns.py
@@ -8,6 +8,7 @@ REPLY_PATTERNS = [
     u'^Le (.*) a écrit :$', # French
     u'El (.*) escribió:$', # Spanish
     u'^(.*) написал\(а\):$',  # Russian
+    u'^(.*) skrev (.*):$',
     u'^Den (.*) skrev (.*):$', # Swedish
     u'^Em (.*) escreveu:$', # Brazillian portuguese
     u'([0-9]{4}/[0-9]{1,2}/[0-9]{1,2}) (.* <.*@.*>)$', # gmail (?) reply


### PR DESCRIPTION
Some talon tests were failing to strip because there weren't enough patterns for other languages.... This PR adds the norwegian pattern to quote strip better so as to make some tests like `Quotes: Strip quotes from Norwegian Gmail`  in [emailservice](https://github.com/dixahq/emailservice/blob/develop/src/test/scala/com/dixa/emailservice/talon/TalonSpec.scala) pass.  

In likewise fashion, if we suspect that some languages don't properly quote strip, we can just add the pattern here ourselves. 