### PR TITLE
Align master with develop

### DIFF
--- a/quotequail/_patterns.py
+++ b/quotequail/_patterns.py
@@ -8,6 +8,7 @@ REPLY_PATTERNS = [
     u'^Le (.*) a écrit :$', # French
     u'El (.*) escribió:$', # Spanish
     u'^(.*) написал\(а\):$',  # Russian
+    u'^(.*) skrev (.*):$',
     u'^Den (.*) skrev (.*):$', # Swedish
     u'^Em (.*) escreveu:$', # Brazillian portuguese
     u'([0-9]{4}/[0-9]{1,2}/[0-9]{1,2}) (.* <.*@.*>)$', # gmail (?) reply


### PR DESCRIPTION
email-quote-stripper lambda has develop version running in all environments.
Aligning master with develop.

Would be great to get rid of develop, but there are no settings available.